### PR TITLE
[feat/swiper] 메인 상단 탭, 메인 컨텐츠 영역 swiper 추가 

### DIFF
--- a/css/common.css
+++ b/css/common.css
@@ -80,6 +80,35 @@ button {
 	height: 2px;
 	background: var(--main-color);
 }
+.swiper_btn_navi {
+	width: 32px;
+	height: 32px;
+	border-radius: 32px;
+	border: 1px solid rgb(0, 0, 0, 0.3);
+	background: rgba(255, 255, 255, 0.9);
+	font-size: 0;
+}
+.swiper_btn_navi:hover {
+	box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.18);
+	background: var(--white);
+}
+.swiper_btn_navi::after {
+	content: "";
+	width: 12px;
+	height: 12px;
+	background-image: url("./../images/sprite.png");
+	background-repeat: no-repeat;
+}
+.swiper-button-prev::after {
+	background-position: -16px -32px;
+}
+.swiper-button-next::after {
+	background-position: -28px -32px;
+}
+.swiper-button-next.swiper-button-disabled,
+.swiper-button-prev.swiper-button-disabled {
+	opacity: 0;
+}
 
 /* ----------------------- header ----------------------- */
 /* header - header_top */
@@ -343,6 +372,11 @@ button {
 	z-index: 9;
 	box-shadow: 0 0 6px rgba(0, 0, 0, 0.16);
 }
+.main_tab_list_view {
+	flex: 1;
+	position: relative;
+	overflow: hidden;
+}
 .main_tab_menu_list {
 	display: flex;
 	padding-top: 16px;
@@ -350,6 +384,9 @@ button {
 .tab_menu_item {
 	margin: 16px 16px 0px 16px;
 	opacity: 0.674;
+	width: auto;
+	height: auto;
+	flex-shrink: 1;
 }
 .tab_menu_item:first-child {
 	margin-left: 0;
@@ -377,6 +414,7 @@ button {
 	background-position: -96px -106px;
 }
 .tab_menu_tit {
+	width: max-content;
 	padding-bottom: 14px;
 	margin-top: 8px;
 	font-size: var(--fs-caption);
@@ -387,6 +425,18 @@ button {
 }
 .tab_menu_item.selected .tab_menu_tit {
 	border-bottom: solid 2px var(--main-color);
+}
+.main_tab_navi_btns {
+}
+.btn_main_tab_navi {
+	position: absolute;
+	top: 50%;
+}
+.btn_main_tab_navi.swiper-button-prev {
+	left: 8px;
+}
+.btn_main_tab_navi.swiper-button-next {
+	right: 8px;
 }
 /* button filter */
 .btn_filter {
@@ -450,11 +500,37 @@ button {
 	height: 100%;
 	padding: 10px;
 	box-sizing: border-box;
+	z-index: 2;
+	background: linear-gradient(180deg, transparent 80%, rgba(0, 0, 0, 0.25));
 }
 .main_content_item_buttons .top {
+	flex: 1;
 	display: flex;
-	align-items: center;
+	align-items: flex-start;
 	justify-content: space-between;
+}
+.main_content_item_navi {
+	flex: 1;
+}
+.main_content_item_pagination.swiper-pagination-horizontal.swiper-pagination-bullets.swiper-pagination-bullets-dynamic {
+	flex: 1;
+	transform: none;
+	margin: 0 auto;
+	display: flex;
+	align-items: flex-end;
+	justify-content: center;
+}
+.main_content_item_pagination.swiper-pagination-horizontal.swiper-pagination-bullets.swiper-pagination-bullets-dynamic .swiper-pagination-bullet {
+	width: 6px;
+	height: 6px;
+	margin: 0 3px;
+	background: var(--white);
+	opacity: 1;
+	transform: none;
+	background: rgba(255, 255, 255, 0.6);
+}
+.main_content_item_pagination.swiper-pagination-horizontal.swiper-pagination-bullets.swiper-pagination-bullets-dynamic .swiper-pagination-bullet-active-main {
+	background: var(--white);
 }
 .guest_favorite {
 	display: flex;
@@ -493,6 +569,7 @@ button {
 	background-repeat: no-repeat;
 	background-position: -62px -80px;
 }
+
 /* main - content : main_content_thumbnail_info */
 .main_content_thumbnail_info {
 	position: relative;

--- a/index.html
+++ b/index.html
@@ -4,7 +4,9 @@
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 		<link href="./css/reset.css" rel="stylesheet" />
+		<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swiper@11/swiper-bundle.min.css" />
 		<link href="./css/common.css" rel="stylesheet" />
+
 		<title>클론 에어비엔비 - 신나현</title>
 	</head>
 	<body>
@@ -108,29 +110,33 @@
 			</header>
 			<main class="main">
 				<div class="main_tab_area">
-					<div class="main_tab_list_view">
-						<ul class="main_tab_menu_list">
-							<li class="tab_menu_item">
+					<div class="main_tab_list_view swiper-container">
+						<ul class="main_tab_menu_list swiper-wrapper">
+							<li class="tab_menu_item swiper-slide">
 								<div class="tab_menu_icon hanok"></div>
 								<div class="tab_menu_tit">한옥</div>
 							</li>
-							<li class="tab_menu_item selected">
+							<li class="tab_menu_item selected swiper-slide">
 								<div class="tab_menu_icon pool"></div>
 								<div class="tab_menu_tit">멋진 수영장</div>
 							</li>
-							<li class="tab_menu_item">
+							<li class="tab_menu_item swiper-slide">
 								<div class="tab_menu_icon coast"></div>
 								<div class="tab_menu_tit">해변 바로 앞</div>
 							</li>
-							<li class="tab_menu_item">
+							<li class="tab_menu_item swiper-slide">
 								<div class="tab_menu_icon creative"></div>
 								<div class="tab_menu_tit">창작 공간</div>
 							</li>
-							<li class="tab_menu_item">
+							<li class="tab_menu_item swiper-slide">
 								<div class="tab_menu_icon country"></div>
 								<div class="tab_menu_tit">한적한 시골</div>
 							</li>
 						</ul>
+						<div class="main_tab_navi_btns">
+							<div class="btn_main_tab_navi swiper_btn_navi swiper-button-prev"></div>
+							<div class="btn_main_tab_navi swiper_btn_navi swiper-button-next"></div>
+						</div>
 					</div>
 					<button class="btn_filter"><span class="icon_filter"></span>필터</button>
 				</div>
@@ -139,8 +145,13 @@
 						<li class="main_content_item">
 							<a href="" title="클릭시 상세페이지로 이동">
 								<div class="main_content_item_wrap">
-									<div class="main_content_tnumbnail_area">
-										<div class="main_content_item_images"><img src="./images/main_content_img_01.jpg" alt="숙소이미지_임시_1" /></div>
+									<div class="main_content_tnumbnail_area swiper-container" id="mainContentSlide01">
+										<div class="main_content_item_images swiper-wrapper">
+											<div class="main_content_img_item swiper-slide"><img src="./images/main_content_img_01.jpg" alt="숙소이미지_임시_1" /></div>
+											<div class="main_content_img_item swiper-slide"><img src="./images/main_content_img_02.jpg" alt="숙소이미지_임시_1" /></div>
+											<div class="main_content_img_item swiper-slide"><img src="./images/main_content_img_01.jpg" alt="숙소이미지_임시_1" /></div>
+											<div class="main_content_img_item swiper-slide"><img src="./images/main_content_img_02.jpg" alt="숙소이미지_임시_1" /></div>
+										</div>
 										<div class="main_content_item_buttons">
 											<div class="top">
 												<div class="guest_favorite">
@@ -150,8 +161,8 @@
 												<button class="btn_like"><span class="icon_heart"></span>좋아요</button>
 											</div>
 											<div class="main_content_item_navi">
-												<button class="btn_prev">이전</button>
-												<button class="btn_next">다음</button>
+												<button class="btn_main_content_navi btn_prev swiper_btn_navi swiper-button-next">이전</button>
+												<button class="btn_main_content_navi btn_next swiper_btn_navi swiper-button-prev">다음</button>
 											</div>
 											<div class="main_content_item_pagination"></div>
 										</div>
@@ -170,38 +181,13 @@
 						<li class="main_content_item">
 							<a href="" title="클릭시 상세페이지로 이동">
 								<div class="main_content_item_wrap">
-									<div class="main_content_tnumbnail_area">
-										<div class="main_content_item_images"><img src="./images/main_content_img_01.jpg" alt="숙소이미지_임시_1" /></div>
-										<div class="main_content_item_buttons">
-											<div class="top">
-												<div class="guest_favorite">
-													<div class="icon_trophy"></div>
-													게스트 선호
-												</div>
-												<button class="btn_like"><span class="icon_heart"></span>좋아요</button>
-											</div>
-											<div class="main_content_item_navi">
-												<button class="btn_prev">이전</button>
-												<button class="btn_next">다음</button>
-											</div>
-											<div class="main_content_item_pagination"></div>
+									<div class="main_content_tnumbnail_area swiper-container" id="mainContentSlide02">
+										<div class="main_content_item_images swiper-wrapper">
+											<div class="main_content_img_item swiper-slide"><img src="./images/main_content_img_01.jpg" alt="숙소이미지_임시_1" /></div>
+											<div class="main_content_img_item swiper-slide"><img src="./images/main_content_img_02.jpg" alt="숙소이미지_임시_1" /></div>
+											<div class="main_content_img_item swiper-slide"><img src="./images/main_content_img_01.jpg" alt="숙소이미지_임시_1" /></div>
+											<div class="main_content_img_item swiper-slide"><img src="./images/main_content_img_02.jpg" alt="숙소이미지_임시_1" /></div>
 										</div>
-									</div>
-									<dl class="main_content_thumbnail_info">
-										<dt class="item_element item_tit">한국 가평군</dt>
-										<dd class="item_element item_distance">44km거리</dd>
-										<dd class="item_element item_date">4월 20일 ~25일</dd>
-										<dd class="item_element item_price">₩395,766&#47;박</dd>
-										<dd class="item_element item_score">4.45</dd>
-									</dl>
-								</div>
-							</a>
-						</li>
-						<li class="main_content_item">
-							<a href="" title="클릭시 상세페이지로 이동">
-								<div class="main_content_item_wrap">
-									<div class="main_content_tnumbnail_area">
-										<div class="main_content_item_images"><img src="./images/main_content_img_01.jpg" alt="숙소이미지_임시_1" /></div>
 										<div class="main_content_item_buttons">
 											<div class="top">
 												<div class="guest_favorite">
@@ -211,158 +197,8 @@
 												<button class="btn_like"><span class="icon_heart"></span>좋아요</button>
 											</div>
 											<div class="main_content_item_navi">
-												<button class="btn_prev">이전</button>
-												<button class="btn_next">다음</button>
-											</div>
-											<div class="main_content_item_pagination"></div>
-										</div>
-									</div>
-									<dl class="main_content_thumbnail_info">
-										<dt class="item_element item_tit">한국 가평군</dt>
-										<dd class="item_element item_distance">44km거리</dd>
-										<dd class="item_element item_date">4월 20일 ~25일</dd>
-										<dd class="item_element item_price">₩395,766&#47;박</dd>
-										<dd class="item_element item_score">4.45</dd>
-									</dl>
-								</div>
-							</a>
-						</li>
-						<li class="main_content_item">
-							<a href="" title="클릭시 상세페이지로 이동">
-								<div class="main_content_item_wrap">
-									<div class="main_content_tnumbnail_area">
-										<div class="main_content_item_images"><img src="./images/main_content_img_01.jpg" alt="숙소이미지_임시_1" /></div>
-										<div class="main_content_item_buttons">
-											<div class="top">
-												<div class="guest_favorite">
-													<div class="icon_trophy"></div>
-													게스트 선호
-												</div>
-												<button class="btn_like"><span class="icon_heart"></span>좋아요</button>
-											</div>
-											<div class="main_content_item_navi">
-												<button class="btn_prev">이전</button>
-												<button class="btn_next">다음</button>
-											</div>
-											<div class="main_content_item_pagination"></div>
-										</div>
-									</div>
-									<dl class="main_content_thumbnail_info">
-										<dt class="item_element item_tit">한국 가평군</dt>
-										<dd class="item_element item_distance">44km거리</dd>
-										<dd class="item_element item_date">4월 20일 ~25일</dd>
-										<dd class="item_element item_price">₩395,766&#47;박</dd>
-										<dd class="item_element item_score">4.45</dd>
-									</dl>
-								</div>
-							</a>
-						</li>
-						<li class="main_content_item">
-							<a href="" title="클릭시 상세페이지로 이동">
-								<div class="main_content_item_wrap">
-									<div class="main_content_tnumbnail_area">
-										<div class="main_content_item_images"><img src="./images/main_content_img_01.jpg" alt="숙소이미지_임시_1" /></div>
-										<div class="main_content_item_buttons">
-											<div class="top">
-												<div class="guest_favorite">
-													<div class="icon_trophy"></div>
-													게스트 선호
-												</div>
-												<button class="btn_like"><span class="icon_heart"></span>좋아요</button>
-											</div>
-											<div class="main_content_item_navi">
-												<button class="btn_prev">이전</button>
-												<button class="btn_next">다음</button>
-											</div>
-											<div class="main_content_item_pagination"></div>
-										</div>
-									</div>
-									<dl class="main_content_thumbnail_info">
-										<dt class="item_element item_tit">한국 가평군</dt>
-										<dd class="item_element item_distance">44km거리</dd>
-										<dd class="item_element item_date">4월 20일 ~25일</dd>
-										<dd class="item_element item_price">₩395,766&#47;박</dd>
-										<dd class="item_element item_score">4.45</dd>
-									</dl>
-								</div>
-							</a>
-						</li>
-						<li class="main_content_item">
-							<a href="" title="클릭시 상세페이지로 이동">
-								<div class="main_content_item_wrap">
-									<div class="main_content_tnumbnail_area">
-										<div class="main_content_item_images"><img src="./images/main_content_img_01.jpg" alt="숙소이미지_임시_1" /></div>
-										<div class="main_content_item_buttons">
-											<div class="top">
-												<div class="guest_favorite">
-													<div class="icon_trophy"></div>
-													게스트 선호
-												</div>
-												<button class="btn_like"><span class="icon_heart"></span>좋아요</button>
-											</div>
-											<div class="main_content_item_navi">
-												<button class="btn_prev">이전</button>
-												<button class="btn_next">다음</button>
-											</div>
-											<div class="main_content_item_pagination"></div>
-										</div>
-									</div>
-									<dl class="main_content_thumbnail_info">
-										<dt class="item_element item_tit">한국 가평군</dt>
-										<dd class="item_element item_distance">44km거리</dd>
-										<dd class="item_element item_date">4월 20일 ~25일</dd>
-										<dd class="item_element item_price">₩395,766&#47;박</dd>
-										<dd class="item_element item_score">4.45</dd>
-									</dl>
-								</div>
-							</a>
-						</li>
-						<li class="main_content_item">
-							<a href="" title="클릭시 상세페이지로 이동">
-								<div class="main_content_item_wrap">
-									<div class="main_content_tnumbnail_area">
-										<div class="main_content_item_images"><img src="./images/main_content_img_01.jpg" alt="숙소이미지_임시_1" /></div>
-										<div class="main_content_item_buttons">
-											<div class="top">
-												<div class="guest_favorite">
-													<div class="icon_trophy"></div>
-													게스트 선호
-												</div>
-												<button class="btn_like"><span class="icon_heart"></span>좋아요</button>
-											</div>
-											<div class="main_content_item_navi">
-												<button class="btn_prev">이전</button>
-												<button class="btn_next">다음</button>
-											</div>
-											<div class="main_content_item_pagination"></div>
-										</div>
-									</div>
-									<dl class="main_content_thumbnail_info">
-										<dt class="item_element item_tit">한국 가평군</dt>
-										<dd class="item_element item_distance">44km거리</dd>
-										<dd class="item_element item_date">4월 20일 ~25일</dd>
-										<dd class="item_element item_price">₩395,766&#47;박</dd>
-										<dd class="item_element item_score">4.45</dd>
-									</dl>
-								</div>
-							</a>
-						</li>
-						<li class="main_content_item">
-							<a href="" title="클릭시 상세페이지로 이동">
-								<div class="main_content_item_wrap">
-									<div class="main_content_tnumbnail_area">
-										<div class="main_content_item_images"><img src="./images/main_content_img_01.jpg" alt="숙소이미지_임시_1" /></div>
-										<div class="main_content_item_buttons">
-											<div class="top">
-												<div class="guest_favorite">
-													<div class="icon_trophy"></div>
-													게스트 선호
-												</div>
-												<button class="btn_like"><span class="icon_heart"></span>좋아요</button>
-											</div>
-											<div class="main_content_item_navi">
-												<button class="btn_prev">이전</button>
-												<button class="btn_next">다음</button>
+												<button class="btn_main_content_navi btn_prev swiper_btn_navi swiper-button-next">이전</button>
+												<button class="btn_main_content_navi btn_next swiper_btn_navi swiper-button-prev">다음</button>
 											</div>
 											<div class="main_content_item_pagination"></div>
 										</div>
@@ -911,6 +747,7 @@
 			</div>
 		</div>
 		<!-- end: popup_wrap -->
+		<script src="https://cdn.jsdelivr.net/npm/swiper@11/swiper-bundle.min.js"></script>
 		<script type="text/javascript" src="./js/index.js"></script>
 	</body>
 </html>

--- a/js/index.js
+++ b/js/index.js
@@ -77,3 +77,39 @@ $btnLoginSignUp.forEach((element) => {
 		popupAddActive($popupWrapLoginSignUp, $popupLoginSignUp);
 	});
 });
+
+//swiper
+//swiper : 메인 상단 탭메뉴
+const swiperMainTab = new Swiper(".main_tab_list_view", {
+	spaceBetween: 0,
+	slidesPerView: "auto",
+	freeMode: true,
+	navigation: {
+		nextEl: ".btn_main_tab_navi.swiper-button-next",
+		prevEl: ".btn_main_tab_navi.swiper-button-prev",
+	},
+});
+//swiper: 메인 컨텐츠 개별 슬라이드
+const swiperMainContent = new Swiper("#mainContentSlide01", {
+	spaceBetween: 0,
+	navigation: {
+		nextEl: ".main_content_item_navi .btn_prev",
+		prevEl: ".main_content_item_navi .btn_next",
+	},
+	pagination: {
+		el: ".main_content_item_pagination",
+		dynamicBullets: true,
+	},
+});
+//임시
+const swiperMainContent02 = new Swiper("#mainContentSlide02", {
+	spaceBetween: 0,
+	navigation: {
+		nextEl: ".main_content_item_navi .btn_prev",
+		prevEl: ".main_content_item_navi .btn_next",
+	},
+	pagination: {
+		el: ".main_content_item_pagination",
+		dynamicBullets: true,
+	},
+});


### PR DESCRIPTION
# worklog
* 메인 상단 탭, 메인 컨텐츠 영역 swiper 추가 
* 해당 기능에 맞추어 마크업, CSS 추가 및 수정

# 느낀 점 및 어려운 점
* 메인 상단 탭의 각 아이템별 너비를 유지하면서 슬라이드시 뷰포트만큼 이동하게 하려면 swiper에 별도로 콜백함수를 지정해주어야 합니다. 콜백함수 없이 CSS를 이용하여 제어하려고 했으나 아이템 수가 뷰포트 보다 작아지는 경우와 많아지는 경우 둘 다 제어할 수 없었습니다.
추후에 고도화로 작업하려고 합니다.
* 메인컨텐츠의 swiper 부분은 임시로 몇 개만 불러왔습니다. 실제로는 각 컨텐츠 마다 swiper를 생성해야 하는데 이 경우 더미데이터를 가져와 동적으로 메인컨텐츠를 생성하도록 할 때 바뀌어야 할 것 같습니다. 현재는 임시로 2개를 생성해 놓았습니다.

# 참고사항
작업은 거의 끝났습니다. 팝업의 펼치기 접기 기능만 추가하면 작업은 대강 완성될 것 같습니다.